### PR TITLE
Call actions correctly

### DIFF
--- a/wp-search-ignore-block-names.php
+++ b/wp-search-ignore-block-names.php
@@ -174,4 +174,4 @@ class IgnoreBlockNameInSearch {
 global $ignore_block_name_in_search;
 $ignore_block_name_in_search = new IgnoreBlockNameInSearch();
 
-register_activation_hook( __FILE__, array( 'IgnoreBlockNameInSearch', $ignore_block_name_in_search->activation_check() ) );
+register_activation_hook( __FILE__, array( $ignore_block_name_in_search, 'activation_check' ) );

--- a/wp-search-ignore-block-names.php
+++ b/wp-search-ignore-block-names.php
@@ -83,7 +83,7 @@ class IgnoreBlockNameInSearch {
 	 *
 	 * @return void
 	 */
-	private function check_version() {
+	public function check_version() {
 		if ( ! $this->compatible_version() ) {
 			if ( is_plugin_active( plugin_basename( __FILE__ ) ) ) {
 				deactivate_plugins( plugin_basename( __FILE__ ) );
@@ -100,7 +100,7 @@ class IgnoreBlockNameInSearch {
 	 *
 	 * @return void
 	 */
-	private function disabled_notice() {
+	public function disabled_notice() {
 		$error_message  = '<div class="notice notice-error is-dismissible">';
 		$error_message .= '<p><strong>' . esc_html__( 'Plugin deactivated!', 'ignore-block-name-in-search' ) . '</strong> ';
 		$error_message .= esc_html__( 'The version of your database software does not support REGEXP_REPLACE. Please upgrade to MySQL 8.0.4+ or MariaDB 10.0.5+.', 'ignore-block-name-in-search' );


### PR DESCRIPTION
Actions need to be callables.

Like a function:
```
function something() {

}
add_action('hook', 'something');
```

For a _static_ method in a class:
```
class Something {
  public static function foo() {

  }
}
add_action('hook', [Something::class, 'foo']);
```

For a normal method in a class, you need to provide a concrete instance of that class:
```
class Something {
  public function foo() {

  }
}
$something = new Something();
add_action('hook', [$something, 'foo']);
```

Additionally: All methods you use for a hook must be public.

This PR attempts to fix some issues in the 6-prevent-activation branch.